### PR TITLE
Feat sequelize models

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,21 @@
+{
+  "development": {
+    "url": "postgres://znnggwkr:JeND7zGqOWgKrSuDHedZIi8g4nwOoDEM@balarama.db.elephantsql.com:5432/znnggwkr",
+    "dialect": "postgres",
+    "operatorsAliases": "0"
+  },
+  "test": {
+    "username": "root",
+    "password": null,
+    "database": "database_test",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
+  },
+  "production": {
+    "username": "root",
+    "password": null,
+    "database": "database_production",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
+  }
+}

--- a/migrations/20200629170853-create-teacher.js
+++ b/migrations/20200629170853-create-teacher.js
@@ -1,0 +1,37 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('teachers', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('teachers');
+  },
+};

--- a/migrations/20200629171118-create-student.js
+++ b/migrations/20200629171118-create-student.js
@@ -1,0 +1,37 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('students', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      email: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      password: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('students');
+  },
+};

--- a/migrations/20200629171405-create-subject.js
+++ b/migrations/20200629171405-create-subject.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('subjects', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('subjects');
+  },
+};

--- a/migrations/20200629171719-create-question.js
+++ b/migrations/20200629171719-create-question.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('questions', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      text: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('questions');
+  },
+};

--- a/migrations/20200629172001-create-answer.js
+++ b/migrations/20200629172001-create-answer.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('answers', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      text: {
+        type: Sequelize.STRING,
+      },
+      correct: {
+        type: Sequelize.BOOLEAN,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('answers');
+  },
+};

--- a/migrations/20200629172307-set-up-relations.js
+++ b/migrations/20200629172307-set-up-relations.js
@@ -1,0 +1,27 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('questions', 'subjectId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'subjects',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+    await queryInterface.addColumn('answers', 'questionId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'questions',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('questions', 'subjectId');
+    await queryInterface.removeColumn('answers', 'questionId');
+  },
+};

--- a/migrations/20200629172951-create-test.js
+++ b/migrations/20200629172951-create-test.js
@@ -1,0 +1,42 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('tests', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      question1: {
+        type: Sequelize.INTEGER,
+      },
+      question2: {
+        type: Sequelize.INTEGER,
+      },
+      question3: {
+        type: Sequelize.INTEGER,
+      },
+      answer1: {
+        type: Sequelize.INTEGER,
+      },
+      answer2: {
+        type: Sequelize.INTEGER,
+      },
+      answer3: {
+        type: Sequelize.INTEGER,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('tests');
+  },
+};

--- a/migrations/20200629173136-set-up-relations.js
+++ b/migrations/20200629173136-set-up-relations.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('tests', 'subjectId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'subjects',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+    await queryInterface.addColumn('tests', 'studentId', {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'students',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('tests', 'subjectId');
+    await queryInterface.removeColumn('tests', 'studentId');
+  },
+};

--- a/models/answer.js
+++ b/models/answer.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // to be defined
+      answer.belongsTo(models.question);
     }
   }
   answer.init(

--- a/models/answer.js
+++ b/models/answer.js
@@ -1,0 +1,25 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class answer extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // to be defined
+    }
+  }
+  answer.init(
+    {
+      text: DataTypes.STRING,
+      correct: DataTypes.BOOLEAN,
+    },
+    {
+      sequelize,
+      modelName: 'answer',
+    }
+  );
+  return answer;
+};

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const basename = path.basename(__filename);
+const env = process.env.NODE_ENV || 'development';
+const config = require(__dirname + '/../config/config.json')[env];
+const db = {};
+
+let sequelize;
+if (config.use_env_variable) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config.url, config);
+}
+
+fs.readdirSync(__dirname)
+  .filter((file) => {
+    return (
+      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
+    );
+  })
+  .forEach((file) => {
+    const model = require(path.join(__dirname, file))(
+      sequelize,
+      Sequelize.DataTypes
+    );
+    db[model.name] = model;
+  });
+
+Object.keys(db).forEach((modelName) => {
+  if (db[modelName].associate) {
+    db[modelName].associate(db);
+  }
+});
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;

--- a/models/question.js
+++ b/models/question.js
@@ -1,0 +1,24 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class question extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define relations later
+    }
+  }
+  question.init(
+    {
+      text: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: 'question',
+    }
+  );
+  return question;
+};

--- a/models/question.js
+++ b/models/question.js
@@ -8,7 +8,8 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define relations later
+      question.belongsTo(models.subject);
+      question.hasMany(models.answer);
     }
   }
   question.init(

--- a/models/student.js
+++ b/models/student.js
@@ -1,0 +1,26 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class student extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define relation
+    }
+  }
+  student.init(
+    {
+      name: { type: DataTypes.STRING, allowNull: false },
+      email: { type: DataTypes.STRING, allowNull: false, unique: true },
+      password: { type: DataTypes.STRING, allowNull: false },
+    },
+    {
+      sequelize,
+      modelName: 'student',
+    }
+  );
+  return student;
+};

--- a/models/student.js
+++ b/models/student.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define relation
+      student.hasMany(models.test);
     }
   }
   student.init(

--- a/models/subject.js
+++ b/models/subject.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define relations
+      subject.hasMany(models.question);
     }
   }
   subject.init(

--- a/models/subject.js
+++ b/models/subject.js
@@ -9,6 +9,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       subject.hasMany(models.question);
+      subject.hasMany(models.test);
     }
   }
   subject.init(

--- a/models/subject.js
+++ b/models/subject.js
@@ -1,0 +1,24 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class subject extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define relations
+    }
+  }
+  subject.init(
+    {
+      name: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: 'subject',
+    }
+  );
+  return subject;
+};

--- a/models/teacher.js
+++ b/models/teacher.js
@@ -1,0 +1,26 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class teacher extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  teacher.init(
+    {
+      name: { type: DataTypes.STRING, allowNull: false },
+      email: { type: DataTypes.STRING, allowNull: false, unique: true },
+      password: { type: DataTypes.STRING, allowNull: false },
+    },
+    {
+      sequelize,
+      modelName: 'teacher',
+    }
+  );
+  return teacher;
+};

--- a/models/test.js
+++ b/models/test.js
@@ -8,7 +8,8 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // to be defined
+      test.belongsTo(models.subject);
+      test.belongsTo(models.student);
     }
   }
   test.init(

--- a/models/test.js
+++ b/models/test.js
@@ -1,0 +1,29 @@
+'use strict';
+const { Model } = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class test extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // to be defined
+    }
+  }
+  test.init(
+    {
+      question1: DataTypes.INTEGER,
+      question2: DataTypes.INTEGER,
+      question3: DataTypes.INTEGER,
+      answer1: DataTypes.INTEGER,
+      answer2: DataTypes.INTEGER,
+      answer3: DataTypes.INTEGER,
+    },
+    {
+      sequelize,
+      modelName: 'test',
+    }
+  );
+  return test;
+};


### PR DESCRIPTION
Created all the models and relations based on the UML diagram as attached.

The models are a stripped down version of what is possible.
The models are set up in a way they can easily be adjusted or extended.

The relation between students and subject is left out, as the relation between teacher and subject. These relations would make it more interesting. You could have obligatory and voluntary subjects. A teacher not teaching all the subjects, but a selection. Also you could have different sizes for the test, now 3 questions. And instead of 1 or 0 points for an answer, you could register the id number of the answer for a more detailed analysis.

Due to the limited time frame, the set up is as in primary school: one teacher teaches all the subjects to a group of students.

<img width="1082" alt="db-models-dashboard" src="https://user-images.githubusercontent.com/60842970/86037491-be803280-ba3f-11ea-874e-93b41bff73df.png">
