### PR TITLE
Add seeds with bash command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-release: npx sequelize-cli db:migrate
+release: bash post-release.sh

--- a/post-release.sh
+++ b/post-release.sh
@@ -1,0 +1,2 @@
+npx sequelize-cli db:migrate
+npx sequelize-cli db:seed:all


### PR DESCRIPTION
I created a bash command to seed the database with some data I had prepared.

Everything seems to work without any data. Teacher and students can sign up. Teacher can start building from there, by adding subjects and questions.

To showcase the app, it is nice to have some data ready, hence the seeds.
I will remove the command once the database is seeded.